### PR TITLE
Component/Application Helm deployment

### DIFF
--- a/charts/kubefox/Chart.yaml
+++ b/charts/kubefox/Chart.yaml
@@ -10,27 +10,34 @@ dependencies:
     name: cert-manager
     repository: https://charts.jetstack.io
     version: "v1.8.0"
+    condition: global.deployKubefox
   - alias: fluentbit
     name: fluent-bit
     repository: https://fluent.github.io/helm-charts
     version: "0.20.0"
+    condition: global.deployKubefox
   - alias: jaeger
     name: jaeger
     repository: https://jaegertracing.github.io/helm-charts
     version: "0.56.5"
+    condition: global.deployKubefox   
   - alias: nats
     name: nats
     repository: https://nats-io.github.io/k8s/helm/charts
     version: "0.17.0"
+    condition: global.deployKubefox     
   - alias: opensearch
     name: opensearch
     repository: https://opensearch-project.github.io/helm-charts
     version: "1.11.1"
+    condition: global.deployKubefox   
   - alias: prometheus
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
     version: "35.2.0"
+    condition: global.deployKubefox    
   - alias: traefik
     name: traefik
     repository: https://helm.traefik.io/traefik
     version: "10.19.5"
+    condition: global.deployKubefox     

--- a/charts/kubefox/charts/metacontroller-helm/templates/clusterrole-aggregate-edit.yaml
+++ b/charts/kubefox/charts/metacontroller-helm/templates/clusterrole-aggregate-edit.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.global.deployKubefox }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/kubefox/charts/metacontroller-helm/templates/clusterrole-aggregate-view.yaml
+++ b/charts/kubefox/charts/metacontroller-helm/templates/clusterrole-aggregate-view.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.global.deployKubefox }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/kubefox/charts/metacontroller-helm/templates/clusterrole.yaml
+++ b/charts/kubefox/charts/metacontroller-helm/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.global.deployKubefox }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/kubefox/charts/metacontroller-helm/templates/clusterrolebinding.yaml
+++ b/charts/kubefox/charts/metacontroller-helm/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.global.deployKubefox }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/kubefox/charts/metacontroller-helm/templates/pdb.yaml
+++ b/charts/kubefox/charts/metacontroller-helm/templates/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.enabled  .Values.global.deployKubefox }}
 {{- if and .Values.podDisruptionBudget (gt (.Values.replicas | int) 1) }}
 apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
@@ -16,3 +17,4 @@ spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end -}}
+{{- end}}

--- a/charts/kubefox/charts/metacontroller-helm/templates/serviceaccount.yaml
+++ b/charts/kubefox/charts/metacontroller-helm/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.enabled  .Values.global.deployKubefox }}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -10,4 +11,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kubefox/charts/metacontroller-helm/templates/statefulset.yaml
+++ b/charts/kubefox/charts/metacontroller-helm/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.enabled  .Values.global.deployKubefox }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -54,3 +55,4 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+{{- end }}

--- a/charts/kubefox/charts/metacontroller-helm/values.yaml
+++ b/charts/kubefox/charts/metacontroller-helm/values.yaml
@@ -1,5 +1,6 @@
+enabled: false
 rbac:
-  create: true
+  create: false
 
 image:
   repository: metacontrollerio/metacontroller

--- a/charts/kubefox/my-application-values.yaml
+++ b/charts/kubefox/my-application-values.yaml
@@ -1,0 +1,15 @@
+global:
+  deployKubefox: false
+kubefoxApplication:
+  deploy: true
+  system: my-system
+  name: my-application
+  ingressDomain: kubefox.net
+  variables: 
+    appVar: hello
+  components:
+    python-hello:
+      image: kubefox/python-hello
+      routes:
+        http: Path('/python-hello')
+

--- a/charts/kubefox/templates/github-runner/github-runner-deployment.yaml
+++ b/charts/kubefox/templates/github-runner/github-runner-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           imagePullPolicy: Always
           envFrom:
             - secretRef:
-              name: {{ include "kubefox.fullname" . }}-github-runner
+                name: {{ include "kubefox.fullname" . }}-github-runner
           env:
             - name: ORG
               value: "{{ .Values.githubRunner.organization }}"

--- a/charts/kubefox/templates/kubefox-application-runtime/cert.yaml
+++ b/charts/kubefox/templates/kubefox-application-runtime/cert.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.kubefoxApplication.deploy}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: demo
+spec:
+  dnsNames:
+    - "{{ .Values.kubefoxApplication.ingressDomain }}" 
+    - "*.{{ .Values.kubefoxApplication.ingressDomain }}"
+  secretName: demo-cert
+  issuerRef:
+    name: letsencrypt
+    kind: Issuer
+{{- end }}

--- a/charts/kubefox/templates/kubefox-application-runtime/deployment.yaml
+++ b/charts/kubefox/templates/kubefox-application-runtime/deployment.yaml
@@ -5,26 +5,14 @@ kind: Deployment
 metadata:
   name: "{{ $comp }}"
   labels:
-    app.kubernetes.io/name: "{{ $.Values.kubefoxApplication.system}}" 
-    kubefox.io/app: "{{ $.Values.kubefoxApplication.name}}"
-    # TODO: Switch to component name
-    kubefox.io/component: "{{ $comp }}"
     {{- include "kubefox.labels" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: "{{ $.Values.kubefoxApplication.system}}" 
-      kubefox.io/app: "{{ $.Values.kubefoxApplication.name}}"
-      # TODO: Switch to component name
-      kubefox.io/component: "{{ $comp }}"
       {{- include "kubefox.selectorLabels" $ | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: "{{ $.Values.kubefoxApplication.system}}" 
-        kubefox.io/app: "{{ $.Values.kubefoxApplication.name}}"
-        # TODO: Switch to component name
-        kubefox.io/component: "{{ $comp }}"
         {{- include "kubefox.labels" $ | nindent 8 }}
     spec:
       containers:

--- a/charts/kubefox/templates/kubefox-application-runtime/deployment.yaml
+++ b/charts/kubefox/templates/kubefox-application-runtime/deployment.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.kubefoxApplication.deploy }}
+{{- range $comp, $v := .Values.kubefoxApplication.components }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ $comp }}"
+  labels:
+    app.kubernetes.io/name: "{{ $.Values.kubefoxApplication.system}}" 
+    kubefox.io/app: "{{ $.Values.kubefoxApplication.name}}"
+    # TODO: Switch to component name
+    kubefox.io/component: "{{ $comp }}"
+    {{- include "kubefox.labels" $ | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ $.Values.kubefoxApplication.system}}" 
+      kubefox.io/app: "{{ $.Values.kubefoxApplication.name}}"
+      # TODO: Switch to component name
+      kubefox.io/component: "{{ $comp }}"
+      {{- include "kubefox.selectorLabels" $ | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "{{ $.Values.kubefoxApplication.system}}" 
+        kubefox.io/app: "{{ $.Values.kubefoxApplication.name}}"
+        # TODO: Switch to component name
+        kubefox.io/component: "{{ $comp }}"
+        {{- include "kubefox.labels" $ | nindent 8 }}
+    spec:
+      containers:
+        - name: "{{ $comp }}"
+          image: "{{ $v.image }}"
+          imagePullPolicy: Always
+          resources: {}
+        - name: broker
+          image: kubefox/broker
+          imagePullPolicy: Always
+          args:
+            - managed
+            # - --dev
+            - --component-name="{{ $comp }}"
+            - --component-version=0.0.0
+            - --nats-addr=kubefox-nats.kubefox-system
+{{- end }}            
+{{- end }}

--- a/charts/kubefox/templates/kubefox-application-runtime/local-service.yaml
+++ b/charts/kubefox/templates/kubefox-application-runtime/local-service.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.kubefoxApplication.deploy }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: local-broker
+spec:
+  type: ExternalName
+  externalName: localhost
+{{- end }}

--- a/charts/kubefox/templates/kubefox-application-runtime/traefik.yaml
+++ b/charts/kubefox/templates/kubefox-application-runtime/traefik.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.kubefoxApplication.deploy }}
+{{- range $comp, $v := .Values.kubefoxApplication.components }}
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: "{{ $comp }}-middleware"
+spec:
+  headers:
+    customRequestHeaders:
+      Kubefox-Target-Url: "kubefox://{{ $comp }}.localcluster"
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: "{{ $comp }}-route"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: "{{ $v.routes.http }}" 
+      kind: Rule
+      services:
+        - name: local-broker
+          port: 8080
+      middlewares:
+        - name: "{{ $comp }}-middleware"
+  tls:
+    secretName: demo-cert
+{{- end }}
+{{- end }}

--- a/charts/kubefox/templates/telemetry/collector-deployment.yaml
+++ b/charts/kubefox/templates/telemetry/collector-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.collector.enabled }}
+{{- if and .Values.collector.enabled .Values.global.deployKubefox }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/kubefox/templates/telemetry/collector-secret.yaml
+++ b/charts/kubefox/templates/telemetry/collector-secret.yaml
@@ -1,4 +1,4 @@
----
+{{- if and .Values.collector.enabled .Values.global.deployKubefox }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -16,3 +16,4 @@ stringData:
     {{- tpl (toYaml .Values.collector.metrics.config) . | nindent 4 }}
   modules.yaml: |
     {{- tpl (toYaml .Values.collector.metrics.modules) . | nindent 4 }}
+{{- end }}

--- a/charts/kubefox/templates/telemetry/collector-service.yaml
+++ b/charts/kubefox/templates/telemetry/collector-service.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.collector.enabled .Values.global.deployKubefox }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,3 +31,4 @@ spec:
   selector:
     app.kubernetes.io/component: collector
     {{- include "kubefox.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/kubefox/values.yaml
+++ b/charts/kubefox/values.yaml
@@ -14,9 +14,13 @@ images:
     repository: docker.elastic.co/beats/metricbeat-oss
     tag: 7.12.1
 
+global:
+  deployKubefox: true
+
 certmanager:
   # TODO: HA
   #       Limit operator only namespaces owned by KF
+  enabled: true
   installCRDs: true
 
   prometheus:
@@ -161,6 +165,7 @@ collector:
     affinity: {}
 
 fluentbit:
+  enabled: true
   flush: 1
   logLevel: info
 
@@ -249,6 +254,7 @@ githubRunner:
       memory: 128Mi
 
 jaeger:
+  enabled: true
   provisionDataStore:
     cassandra: false
     elasticsearch: false
@@ -287,9 +293,13 @@ jaeger:
     agentSidecar:
       enabled: false
 
-metacontroller: {}
+metacontroller-helm:
+  enabled: true
+  rbac:
+    create: true
 
 nats:
+  enabled: true
   nats:
     jetstream:
       enabled: true
@@ -324,6 +334,7 @@ nats:
     enabled: false
 
 opensearch:
+  enabled: true
   clusterName: kubefox-opensearch
   nodeGroup: main
   masterService: kubefox-opensearch-main
@@ -437,6 +448,7 @@ opensearch:
               ]
 
 prometheus:
+  enabled: true
   prometheusOperator:
     enabled: true
   # logFormat: json-formatted
@@ -490,6 +502,7 @@ prometheus:
     enabled: false
 
 traefik:
+  enabled: true
   deployment:
     replicas: 3
 
@@ -599,3 +612,6 @@ traefik:
         headers:
           defaultmode: drop
           names: {}
+
+kubefoxApplication:
+  deploy: false 


### PR DESCRIPTION
- Initial Helm template for deploying an application and its components, routes, etc based on the example my-application/hello-python app in the example repo.

- Adds global flag in values.yaml to differentiate between KubeFox infrastructure deployment and Application/Component deployment. Otherwise by default helm will install ALL child charts/templates.

- Small syntax fix to the secret ref in github runner.